### PR TITLE
not all tx have direct fees visible under first level

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,19 +103,11 @@ var prepareDataStructure = function(blocks) {
                 transaction.block = block.height;
                 myCanceledLeases[transaction.leaseId] = transaction;
             }
-            // considering West fees
-            if (!transaction.feeAsset || transaction.feeAsset === '' || transaction.feeAsset === null) {
-                if (transaction.fee < 10 * Math.pow(10, 8)) {
-                            westFees += transaction.fee;
-                }
-            } else if (transaction.type === 4) {
-                westFees += 10000000;
-            }
         });
         if (previousBlock) {
             block.previousBlockWestFees = previousBlock.westFees;
         }
-        block.westFees = westFees;
+        block.westFees = block.fee;
         previousBlock = block;
     });
 };


### PR DESCRIPTION
using the block fees instead the tx fees, we allow for more flexability which is needed for west tx's.
Checking on fees on tx base is for my understanding a legacy system from when nodes could have been paid in tokens, since this isn't possible anymore, it seems me unneeded.
Using this method also matches with the dev.pywaves.org output from earned fee's.
Therefor this would be my suggestion to make it future proof